### PR TITLE
CSS moduler - Startet på App

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,0 +1,16 @@
+.innholdspanel {
+  margin-top: 5rem;
+  margin-bottom: 8rem;
+}
+
+.knappwrapper {
+  margin-top: 1.5rem;
+  text-align: center;
+}
+
+.sideHeader {
+  background-color: var(--a-purple-200);
+  text-align: center;
+  width: 100%;
+  padding: 1rem;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Spørsmål from './components/spørsmål/Spørsmål';
-import { Button, Loader, Heading, Panel } from '@navikt/ds-react';
+import { Button, Loader, Heading, VStack } from '@navikt/ds-react';
 import Feilside from './components/feilside/Feilside';
 import Header from './components/veiviser-header/Header';
 import {
@@ -14,120 +14,11 @@ import {
   ISpørsmål,
 } from './models/Spørsmål';
 import { scrollTilNesteSpørsmal } from './components/spørsmål/SpørsmålUtils';
-import styled, { createGlobalStyle } from 'styled-components';
-import { device, størrelse } from './utils/styles';
 import { logStartVeiviser } from './utils/amplitude';
 import { IHeader, tomHeaderTekst } from './models/Header';
-import {
-  AGray100,
-  AGray700,
-  AOrange500,
-  APurple200,
-} from '@navikt/ds-tokens/dist/tokens';
-
-const GlobalStyle = createGlobalStyle`
-  html {
-    scroll-behavior: smooth;
-  }
-
-  body {
-    background-color: ${AGray100};
-    margin: 0;
-
-    a:focus {
-      color: ${AGray700};
-      text-decoration: none;
-      background-color: ${AOrange500};
-    }
-  }
-`;
-
-const Container = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-
-  .innholdspanel {
-    margin-top: 5rem;
-    margin-bottom: 8rem;
-    box-sizing: border-box;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-  }
-
-  .knappwrapper {
-    text-align: center;
-  }
-
-  .startknapp {
-    margin-top: 2rem;
-  }
-
-  .panel {
-    width: ${størrelse.panelBredde};
-
-    @media ${device.tablet} {
-      width: 100%;
-    }
-
-    @media ${device.mobile} {
-      width: 100%;
-    }
-  }
-
-  .blur-in {
-    -webkit-animation: text-focus-in 0.25s cubic-bezier(0.55, 0.085, 0.68, 0.53)
-      both;
-    animation: text-focus-in 0.25s cubic-bezier(0.55, 0.085, 0.68, 0.53) both;
-  }
-
-  @-webkit-keyframes blur-in {
-    0% {
-      -webkit-filter: blur(12px);
-      filter: blur(12px);
-      opacity: 0;
-    }
-    100% {
-      -webkit-filter: blur(0);
-      filter: blur(0);
-      opacity: 1;
-    }
-  }
-  @keyframes text-focus-in {
-    0% {
-      -webkit-filter: blur(12px);
-      filter: blur(12px);
-      opacity: 0;
-    }
-    100% {
-      -webkit-filter: blur(0);
-      filter: blur(0);
-      opacity: 1;
-    }
-  }
-
-  .side-header {
-    background-color: ${APurple200};
-    text-align: center;
-    height: 80px;
-    width: 100%;
-    font-weight: bold;
-
-    h1 {
-      line-height: 80px;
-    }
-  }
-`;
-
-const InnholdsWrapper = styled.div`
-  scroll-behavior: smooth;
-  padding: 2rem;
-
-  @media ${device.mobile} {
-    padding: 0;
-  }
-`;
+import { InnholdsContainer } from './components/innholdscontainer/InnholdsContainer';
+import styles from './App.module.css';
+import './global.css';
 
 const App = () => {
   const [spørsmålListe, settSpørsmålListe] = useState<ISpørsmål[]>([]);
@@ -217,6 +108,7 @@ const App = () => {
     fetchDisclaimer();
     fetchAlert();
   }, []);
+
   const startVeiviser = () => {
     settStartet(true);
 
@@ -237,25 +129,26 @@ const App = () => {
 
   return (
     <React.Fragment>
-      <GlobalStyle />
-      <Container>
-        <div className="side-header">
+      <VStack justify={'center'} align={'center'}>
+        <div className={styles.sideHeader}>
           <Heading size="xlarge">Hva kan du få?</Heading>
         </div>
-        <Panel className="innholdspanel">
-          <InnholdsWrapper>
+        <div className={styles.innholdspanel}>
+          <InnholdsContainer>
             <Header tekst={headerTekst} />
-            {!startet ? (
-              <div className="knappwrapper">
+
+            {!startet && (
+              <div className={styles.knappwrapper}>
                 <Button
                   variant="primary"
-                  className="startknapp"
+                  className={styles.startknapp}
                   onClick={startVeiviser}
                 >
                   Start veiviseren
                 </Button>
               </div>
-            ) : null}
+            )}
+
             <Spørsmål
               nesteSpørsmål={nesteSpørsmål}
               startet={startet}
@@ -270,9 +163,9 @@ const App = () => {
               disclaimer={disclaimer}
               alert={alert}
             />
-          </InnholdsWrapper>
-        </Panel>
-      </Container>
+          </InnholdsContainer>
+        </div>
+      </VStack>
     </React.Fragment>
   );
 };

--- a/src/components/informasjonsboks/Informasjonsboks.tsx
+++ b/src/components/informasjonsboks/Informasjonsboks.tsx
@@ -56,6 +56,20 @@ const InfoBoksContainer = styled.div`
   margin: 0 auto;
   margin-top: 4rem;
 
+  animation: blur-in 0.25s cubic-bezier(0.55, 0.085, 0.68, 0.53);
+  animation: text-focus-in 0.25s cubic-bezier(0.55, 0.085, 0.68, 0.53) both;
+
+  @keyframes blur-in, text-focus-in {
+    0% {
+      filter: blur(12px);
+      opacity: 0;
+    }
+    100% {
+      filter: blur(0);
+      opacity: 1;
+    }
+  }
+
   @media ${device.tablet} {
     max-width: ${størrelse.panelInnholdBredde};
     width: 100%;

--- a/src/components/innholdscontainer/InnholdsContainer.module.css
+++ b/src/components/innholdscontainer/InnholdsContainer.module.css
@@ -1,0 +1,8 @@
+.innholdscontainer {
+  background-color: var(--a-white);
+  padding: 3rem;
+
+  @media all and (max-width: 420px) {
+    padding: 1rem;
+  }
+}

--- a/src/components/innholdscontainer/InnholdsContainer.tsx
+++ b/src/components/innholdscontainer/InnholdsContainer.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import styles from './InnholdsContainer.module.css';
+
+export const InnholdsContainer: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
+  return <div className={styles.innholdscontainer}>{children}</div>;
+};

--- a/src/global.css
+++ b/src/global.css
@@ -1,0 +1,14 @@
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  background-color: var(--a-gray-100);
+  margin: 0;
+
+  a:focus {
+    color: var(--a-gray-700);
+    text-decoration: none;
+    background-color: var(--a-orange-500);
+  }
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,4 @@
+declare module '*.module.css' {
+  const classes: { [key: string]: string };
+  export default classes;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,6 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": [
-    "./src/backend/server.ts",
+    "./src/backend/server.ts" , "global.d.ts",
   ]
 }


### PR DESCRIPTION
Skal skrive oss bort fra styled components. Lager flere PR slik at det blir enklere å gå gjennom.

* Lagt tilrette for bruk av css-moduler.
* Startet bortskriving fra styled components i komponentent App.

Endringer er testet på laptop og mobil.

Før:

<img width="3456" height="1756" alt="image" src="https://github.com/user-attachments/assets/bed57a43-b0d3-4b67-b09e-15de79fe2972" />

<img width="792" height="1596" alt="image" src="https://github.com/user-attachments/assets/4f0254de-68f7-4066-b7ab-7402351ba1bb" />


Etter:

<img width="3456" height="1758" alt="image" src="https://github.com/user-attachments/assets/e2ad3067-47f0-40b2-89be-4167947bc4bf" />

<img width="802" height="1596" alt="image" src="https://github.com/user-attachments/assets/34571289-0ed4-425e-ba49-2ebcd948cb7c" />
