### PR TITLE
CSS-moduler fortsettelse

### DIFF
--- a/src/components/feilside/Feilside.tsx
+++ b/src/components/feilside/Feilside.tsx
@@ -1,18 +1,11 @@
 import React from 'react';
 import { Alert } from '@navikt/ds-react';
-import styled from 'styled-components';
-
-const FeilsideWrapper = styled.div`
-  padding: 1rem;
-  width: 400px;
-  margin: auto;
-`;
 
 const Feilside = () => {
   return (
-    <FeilsideWrapper>
-      <Alert variant="error">Noe galt skjedde</Alert>
-    </FeilsideWrapper>
+    <Alert size="small" variant="error">
+      Noe galt skjedde
+    </Alert>
   );
 };
 

--- a/src/components/informasjonsboks/Disclaimer.tsx
+++ b/src/components/informasjonsboks/Disclaimer.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { BodyLong } from '@navikt/ds-react';
+
+export const Disclaimer = ({ tekst }: { tekst: string }) => {
+  return (
+    <div>
+      <BodyLong>{tekst}</BodyLong>
+    </div>
+  );
+};

--- a/src/components/informasjonsboks/Informasjonsboks.module.css
+++ b/src/components/informasjonsboks/Informasjonsboks.module.css
@@ -1,0 +1,128 @@
+.informasjonsboksContainer {
+  border-radius: 8px;
+  -webkit-border-radius: 8px;
+
+  background-color: var(--a-gray-100);
+  width: 588px;
+  min-height: 5rem;
+  margin: 0 auto;
+  margin-top: 4rem;
+
+  animation: blurIn 0.25s cubic-bezier(0.55, 0.085, 0.68, 0.53);
+  animation: text-focus-in 0.25s cubic-bezier(0.55, 0.085, 0.68, 0.53) both;
+
+  @keyframes blurIn, text-focus-in {
+    0% {
+      filter: blur(12px);
+      opacity: 0;
+    }
+    100% {
+      filter: blur(0);
+      opacity: 1;
+    }
+  }
+
+  @media all and (max-width: 959px) {
+    max-width: 588px;
+    width: 100%;
+  }
+
+  @media all and (max-width: 420px) {
+    padding-left: 0;
+    margin-left: 0;
+  }
+
+  ul {
+    padding: 0;
+  }
+
+  hr {
+    margin-top: 4rem;
+    width: 70%;
+    border: solid 0.5px #151515;
+  }
+
+  .listeElement {
+    display: inline;
+    margin-left: 1rem;
+    margin-right: 2rem;
+  }
+
+  .informasjonsboksHeader {
+    position: relative;
+    width: 100%;
+    height: 140px;
+    border-bottom: 0.4rem var(--a-purple-400) solid;
+    background-color: var(--a-purple-200);
+    border-top-left-radius: 8px;
+    border-top-right-radius: 8px;
+    -webkit-border-top-left-radius: 8px;
+    -webkit-border-top-right-radius: 8px;
+
+    .ballIkon {
+      position: absolute;
+      top: 108px;
+      left: 18%;
+
+      @media all and (max-width: 420px) {
+        left: 22%;
+      }
+    }
+
+    .bamseIkon {
+      position: absolute;
+      top: 98px;
+      left: 13%;
+    }
+
+    .bordIkon {
+      position: absolute;
+      top: 118px;
+      left: 55%;
+
+      @media all and (max-width: 420px) {
+        left: 35%;
+      }
+    }
+
+    .barnIkon {
+      position: absolute;
+      top: 54px;
+      left: 70%;
+
+      @media all and (max-width: 420px) {
+        left: 70%;
+      }
+    }
+
+    .barn2Ikon {
+      position: absolute;
+      top: 64px;
+      left: 60%;
+
+      @media all and (max-width: 420px) {
+        left: 50%;
+      }
+    }
+
+    .brodskiveIkon {
+      position: absolute;
+      top: 109px;
+      left: 72%;
+
+      @media all and (max-width: 420px) {
+        left: 73%;
+      }
+    }
+
+    .taateflaskeIkon {
+      position: absolute;
+      top: 95px;
+      left: 59%;
+
+      @media all and (max-width: 420px) {
+        left: 49%;
+      }
+    }
+  }
+}

--- a/src/components/informasjonsboks/Informasjonsboks.tsx
+++ b/src/components/informasjonsboks/Informasjonsboks.tsx
@@ -127,9 +127,9 @@ const Informasjonsboks: React.FC<IInformasjonstekstProps> = ({
           <TaateflaskeIkon className={styles.taateflaskeIkon} />
         </div>
         <VStack
-          gap={{ xs: '2', md: '12' }}
+          gap={{ xs: '2', md: '8' }}
           style={{
-            padding: '0 6rem 1rem 6rem',
+            padding: '0 2rem 1rem 2rem',
           }}
         >
           {rett_til_liste.length ? (

--- a/src/components/informasjonsboks/Informasjonsboks.tsx
+++ b/src/components/informasjonsboks/Informasjonsboks.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { client } from '../../utils/sanity';
-import { Loader } from '@navikt/ds-react';
+import { Loader, VStack } from '@navikt/ds-react';
 import RettTilListe from './rett-til-liste/RettTilListe';
 import { IInformasjonsboks, IUndertittel } from '../../models/Informasjonsboks';
 import UndertitlerPanel from './UndertitlerPanel';
@@ -12,234 +12,17 @@ import Barn2Ikon from '../../icons/Barn2Ikon';
 import BrodskiveIkon from '../../icons/BrodskiveIkon';
 import TaateflaskeIkon from '../../icons/TaateflaskeIkon';
 import Feilside from '../feilside/Feilside';
-import MarkdownViewer from '../utils/MarkdownViewer';
 import { hentInformasjonsboksQuery } from '../../utils/sanity';
-import {
-  StyledAlertstripeAdvarsel,
-  InformasjonsboksInnhold,
-} from './InformasjonsboksElementer';
-import styled from 'styled-components';
-import MikroKort from '../mikrokort/MikroKort';
+import { StyledAlertstripeAdvarsel } from './InformasjonsboksElementer';
+import { MikroKort } from '../mikrokort/MikroKort';
 import { logNavigering } from '../../utils/amplitude';
-import { device, størrelse } from '../../utils/styles';
-import {
-  AGray100,
-  APurple200,
-  APurple400,
-} from '@navikt/ds-tokens/dist/tokens';
-
+import { Disclaimer } from './Disclaimer';
+import styles from './Informasjonsboks.module.css';
 interface IInformasjonstekstProps {
   steg: number;
   disclaimer?: string;
   alert?: string;
 }
-
-export const MikroKortWrapper = styled.div`
-  padding-left: 6rem;
-  padding-right: 6rem;
-
-  padding-bottom: 3rem;
-
-  @media all and (max-width: 420px) {
-    padding-left: 2rem;
-    padding-right: 2rem;
-  }
-`;
-
-const InfoBoksContainer = styled.div`
-  border-radius: 8px;
-  -webkit-border-radius: 8px;
-
-  background-color: ${AGray100};
-  width: ${størrelse.panelInnholdBredde};
-  min-height: 5rem;
-  margin: 0 auto;
-  margin-top: 4rem;
-
-  animation: blur-in 0.25s cubic-bezier(0.55, 0.085, 0.68, 0.53);
-  animation: text-focus-in 0.25s cubic-bezier(0.55, 0.085, 0.68, 0.53) both;
-
-  @keyframes blur-in, text-focus-in {
-    0% {
-      filter: blur(12px);
-      opacity: 0;
-    }
-    100% {
-      filter: blur(0);
-      opacity: 1;
-    }
-  }
-
-  @media ${device.tablet} {
-    max-width: ${størrelse.panelInnholdBredde};
-    width: 100%;
-  }
-
-  @media ${device.mobile} {
-    padding-left: 0;
-    margin-left: 0;
-  }
-
-  ul {
-    padding: 0;
-  }
-
-  hr {
-    margin-top: 4rem;
-    width: 70%;
-    border: solid 0.5px #151515;
-  }
-
-  .liste-element {
-    display: inline;
-    margin-left: 1rem;
-    margin-right: 2rem;
-  }
-
-  .undertittel-flere,
-  .undertittel-singel,
-  .andre-stonader {
-    margin-top: 4rem;
-
-    padding-left: 6rem;
-    padding-right: 6rem;
-
-    @media ${device.mobile} {
-      padding-left: 2rem;
-      padding-right: 2rem;
-    }
-
-    ul {
-      margin-left: 1rem;
-      margin-right: 1rem;
-    }
-  }
-
-  .undertittel-singel {
-    padding-bottom: 6rem;
-  }
-
-  .bare-brodtekst {
-    margin-top: 0;
-
-    padding-left: 6rem;
-    padding-right: 6rem;
-
-    @media ${device.mobile} {
-      padding-left: 2rem;
-      padding-right: 2rem;
-    }
-
-    &-0 {
-      padding-left: 6rem;
-      padding-right: 6rem;
-
-      @media ${device.mobile} {
-        padding-top: 2rem;
-        padding-left: 2rem;
-        padding-right: 2rem;
-      }
-    }
-  }
-
-  .informasjonsboks-header {
-    position: relative;
-    width: 100%;
-    height: 140px;
-    border-bottom: 0.4rem ${APurple400} solid;
-    background-color: ${APurple200};
-    border-top-left-radius: 8px;
-    border-top-right-radius: 8px;
-    -webkit-border-top-left-radius: 8px;
-    -webkit-border-top-right-radius: 8px;
-
-    .ball-ikon {
-      position: absolute;
-      top: 108px;
-      left: 18%;
-
-      @media ${device.mobile} {
-        left: 22%;
-      }
-    }
-
-    .bamse-ikon {
-      position: absolute;
-      top: 98px;
-      left: 13%;
-    }
-
-    .bord-ikon {
-      position: absolute;
-      top: 118px;
-      left: 55%;
-
-      @media ${device.mobile} {
-        left: 35%;
-      }
-    }
-
-    .barn-ikon {
-      position: absolute;
-      top: 54px;
-      left: 70%;
-
-      @media ${device.mobile} {
-        left: 70%;
-      }
-    }
-
-    .barn2-ikon {
-      position: absolute;
-      top: 64px;
-      left: 60%;
-
-      @media ${device.mobile} {
-        left: 50%;
-      }
-    }
-
-    .brodskive-ikon {
-      position: absolute;
-      top: 109px;
-      left: 72%;
-
-      @media ${device.mobile} {
-        left: 73%;
-      }
-    }
-
-    .taateflaske-ikon {
-      position: absolute;
-      top: 95px;
-      left: 59%;
-
-      @media ${device.mobile} {
-        left: 49%;
-      }
-    }
-  }
-
-  .informasjonsboks-innhold {
-    h2 {
-      margin-block-start: 4rem;
-      margin-block-end: 0;
-    }
-
-    .disclaimer {
-      padding: 2rem 6rem 4rem 6rem;
-
-      @media ${device.mobile} {
-        padding-right: 2rem;
-        padding-left: 2rem;
-      }
-    }
-
-    @media ${device.mobile} {
-      padding: 0;
-    }
-  }
-`;
 
 const Informasjonsboks: React.FC<IInformasjonstekstProps> = ({
   steg,
@@ -273,7 +56,7 @@ const Informasjonsboks: React.FC<IInformasjonstekstProps> = ({
   }, [steg]);
 
   if (henter || !(info && info.undertitler)) {
-    return <Loader className="spinner" />;
+    return <Loader className={styles.spinner} />;
   }
 
   if (feil) {
@@ -324,49 +107,55 @@ const Informasjonsboks: React.FC<IInformasjonstekstProps> = ({
 
   return (
     <>
-      {alert ? (
+      {alert && (
         <StyledAlertstripeAdvarsel variant="warning">
           {alert}
         </StyledAlertstripeAdvarsel>
-      ) : null}
-      <InfoBoksContainer className="blur-in" id={`informasjonsboks-${steg}`}>
-        <div className="informasjonsboks-header">
-          <BallIkon className="ball-ikon" />
-          <BamseIkon className="bamse-ikon" />
-          <BarnIkon className="barn-ikon" />
-          <Barn2Ikon className="barn2-ikon" />
-          <BordIkon className="bord-ikon" />
-          <BrodskiveIkon className="brodskive-ikon" />
-          <TaateflaskeIkon className="taateflaske-ikon" />
+      )}
+
+      <div
+        className={`${styles.informasjonsboksContainer} ${styles.blurIn}`}
+        id={`informasjonsboks-${steg}`}
+      >
+        <div className={styles.informasjonsboksHeader}>
+          <BallIkon className={styles.ballIkon} />
+          <BamseIkon className={styles.bamseIkon} />
+          <BarnIkon className={styles.barnIkon} />
+          <Barn2Ikon className={styles.barn2Ikon} />
+          <BordIkon className={styles.bordIkon} />
+          <BrodskiveIkon className={styles.brodskiveIkon} />
+          <TaateflaskeIkon className={styles.taateflaskeIkon} />
         </div>
-        <InformasjonsboksInnhold>
+        <VStack
+          gap={{ xs: '2', md: '12' }}
+          style={{
+            padding: '0 6rem 1rem 6rem',
+          }}
+        >
           {rett_til_liste.length ? (
             <RettTilListe
               tekster_i_liste={rett_til_liste}
               ikke_rett_til={false}
             />
           ) : null}
-          <UndertitlerPanel
-            undertitler={rett_til_undertitler}
-            antall_undertitler_totalt={info.undertitler.length}
-          />
+
+          <UndertitlerPanel undertitler={rett_til_undertitler} />
+
           {ikke_rett_til_liste.length ? (
             <RettTilListe
               tekster_i_liste={ikke_rett_til_liste}
               ikke_rett_til={true}
             />
           ) : null}
+
           <UndertitlerPanel
             undertitler={ikke_rett_til_undertitler}
             antall_undertitler_totalt={info.undertitler.length}
           />
-          {disclaimer ? (
-            <div className="disclaimer">
-              <MarkdownViewer markdown={disclaimer} />
-            </div>
-          ) : null}
 
-          <MikroKortWrapper>
+          {disclaimer && <Disclaimer tekst={disclaimer} />}
+
+          <div>
             <h3>Les mer om hva du kan ha rett til når du</h3>
             <MikroKort
               href="https://www.nav.no/alene-med-barn"
@@ -380,9 +169,9 @@ const Informasjonsboks: React.FC<IInformasjonstekstProps> = ({
             >
               Er helt eller delvis alene med barn
             </MikroKort>
-          </MikroKortWrapper>
-        </InformasjonsboksInnhold>
-      </InfoBoksContainer>
+          </div>
+        </VStack>
+      </div>
     </>
   );
 };

--- a/src/components/informasjonsboks/InformasjonsboksElementer.ts
+++ b/src/components/informasjonsboks/InformasjonsboksElementer.ts
@@ -26,23 +26,3 @@ export const StyledAlertstripeAdvarsel = styled(Alert)`
     }
   }
 `;
-
-export const InformasjonsboksInnhold = styled.div`
-  h2 {
-    margin-block-start: 4rem;
-    margin-block-end: 0;
-  }
-
-  .disclaimer {
-    padding: 2rem 6rem 1rem 6rem;
-
-    @media ${device.mobile} {
-      padding-right: 2rem;
-      padding-left: 2rem;
-    }
-  }
-
-  @media ${device.mobile} {
-    padding: 0;
-  }
-`;

--- a/src/components/informasjonsboks/UndertitlerPanel.tsx
+++ b/src/components/informasjonsboks/UndertitlerPanel.tsx
@@ -11,21 +11,7 @@ interface IUndertitlerPanelProps {
 
 const UndertitlerPanel: React.FC<IUndertitlerPanelProps> = ({
   undertitler,
-  antall_undertitler_totalt,
-  className,
 }) => {
-  const undertitlerIPanel = undertitler.filter(
-    (undertittel) => undertittel.tekst_i_panel
-  );
-
-  const undertittelClass = className
-    ? className
-    : !undertitlerIPanel.length
-    ? 'bare-brodtekst'
-    : antall_undertitler_totalt && antall_undertitler_totalt > 1
-    ? 'undertittel-flere'
-    : 'undertittel-singel';
-
   const undertitlerMedInnhold = undertitler.filter(
     (undertittel) =>
       undertittel.tekst_i_panel ||
@@ -43,17 +29,11 @@ const UndertitlerPanel: React.FC<IUndertitlerPanelProps> = ({
     <>
       {undertitlerMedInnhold.map((undertittel: IUndertittel, i: number) => {
         return (
-          <div
-            className={
-              i === 0 && undertittel.ikke_rett_til
-                ? `${undertittelClass}-0`
-                : undertittelClass
-            }
-            key={i}
-          >
-            {undertittel.tekst_i_panel ? (
+          <div key={i}>
+            {undertittel.tekst_i_panel && (
               <Heading size="small">{undertittel.tekst_i_panel}</Heading>
-            ) : null}
+            )}
+
             {undertittel.brodtekster &&
               undertittel.brodtekster.map(
                 (brodtekst: IBrodtekst, i: number) => {
@@ -69,7 +49,8 @@ const UndertitlerPanel: React.FC<IUndertitlerPanelProps> = ({
                   );
                 }
               )}
-            {visKnapp(undertittel) ? (
+
+            {visKnapp(undertittel) && (
               <a
                 href={undertittel.knapp.lenke}
                 target="_blank"
@@ -78,7 +59,7 @@ const UndertitlerPanel: React.FC<IUndertitlerPanelProps> = ({
               >
                 {undertittel.knapp.tekst}
               </a>
-            ) : null}
+            )}
           </div>
         );
       })}

--- a/src/components/informasjonsboks/rett-til-liste/RettTilListe.tsx
+++ b/src/components/informasjonsboks/rett-til-liste/RettTilListe.tsx
@@ -23,11 +23,6 @@ const RettTilListeWrapper = styled.div`
       padding-bottom: 1rem;
     }
   }
-
-  @media ${device.mobile} {
-    padding-left: 2rem;
-    padding-right: 2rem;
-  }
 `;
 
 const Grid = styled.span`
@@ -48,11 +43,13 @@ const RettTilListe: React.FC<IRettTilListeProps> = ({
   const overskrift = ikke_rett_til
     ? 'Det ser ikke ut til at du har rett til'
     : 'Du kan ha rett til';
+
   const ikon = ikke_rett_til ? (
     <ErrorIkon title={'det ser ikke ut til at du har rett til'} />
   ) : (
     <SuccessIkon title={'du kan ha rett til'} />
   );
+
   const listeLabel = ikke_rett_til
     ? 'Det ser ikke ut til at du har rett til'
     : 'Du kan ha rett til';

--- a/src/components/informasjonsboks/rett-til-liste/RettTilListe.tsx
+++ b/src/components/informasjonsboks/rett-til-liste/RettTilListe.tsx
@@ -24,8 +24,6 @@ const RettTilListeWrapper = styled.div`
     }
   }
 
-  padding-left: 6rem;
-
   @media ${device.mobile} {
     padding-left: 2rem;
     padding-right: 2rem;

--- a/src/components/innholdscontainer/InnholdsContainer.module.css
+++ b/src/components/innholdscontainer/InnholdsContainer.module.css
@@ -1,6 +1,6 @@
 .innholdscontainer {
   background-color: var(--a-white);
-  padding: 3rem;
+  padding: 3rem 4rem;
 
   @media all and (max-width: 420px) {
     padding: 1rem;

--- a/src/components/mikrokort/MikroKort.tsx
+++ b/src/components/mikrokort/MikroKort.tsx
@@ -1,45 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
-import {
-  ABorderAction,
-  ABorderFocus,
-  AOrange200,
-  ATextAction,
-  ATextDefault,
-  ASurfaceAction,
-  AWhite,
-} from '@navikt/ds-tokens/dist/tokens';
-
-const StyledMikroKort = styled.a`
-  border-radius: 1rem;
-  color: ${ATextDefault};
-  display: inline-flex;
-  padding: 0.25rem 0.5rem;
-  text-decoration: none;
-  background-color: ${AOrange200};
-  border: 1px solid transparent;
-  font-weight: bold;
-  font-size: 14px;
-
-  &:hover {
-    background-color: ${AWhite};
-    border-color: ${ABorderAction};
-    color: ${ATextAction};
-    transition: 0.3s;
-    cursor: pointer;
-  }
-
-  &:focus-visible {
-    background-color: ${AOrange200};
-    color: ${ATextDefault};
-    outline: 3px solid ${ABorderFocus};
-  }
-
-  &:active {
-    background-color: ${ASurfaceAction};
-    color: ${AWhite};
-  }
-`;
+import { Chips } from '@navikt/ds-react';
 
 interface MikroKortProps {
   href: string;
@@ -47,12 +7,20 @@ interface MikroKortProps {
   onClick?: () => void;
 }
 
-const MikroKort = ({ href, children, onClick, ...rest }: MikroKortProps) => {
+export const MikroKort = ({ href, children, onClick }: MikroKortProps) => {
   return (
-    <StyledMikroKort href={href} onClick={onClick} {...rest}>
-      {children}
-    </StyledMikroKort>
+    <>
+      <Chips style={{ padding: '0' }}>
+        <Chips.Toggle
+          key={'1'}
+          onClick={onClick}
+          checkmark={false}
+          as="a"
+          href={href}
+        >
+          {children}
+        </Chips.Toggle>
+      </Chips>
+    </>
   );
 };
-
-export default MikroKort;

--- a/src/components/spørsmål/SpørsmålElementer.ts
+++ b/src/components/spørsmål/SpørsmålElementer.ts
@@ -4,7 +4,6 @@ import { Panel } from '@navikt/ds-react';
 
 export const Spørsmålstekst = styled.span`
   display: inline-block;
-  padding-left: ${størrelse.spørsmålTekstPadding};
   padding-right: 2rem;
   font-weight: bold;
   font-size: 20px;
@@ -23,7 +22,6 @@ export const Hjelpetekst = styled(Panel)`
   .lesMerPanel {
     &__toggle {
       justify-content: flex-start;
-      padding-left: ${størrelse.spørsmålTekstPadding};
 
       @media ${device.mobile} {
         padding-left: 0;
@@ -52,7 +50,6 @@ export const SpørsmålElement = styled.div`
   margin-top: 4rem;
 
   p {
-    padding-left: ${størrelse.spørsmålTekstPadding};
     max-width: 500px;
 
     margin-top: -0.5rem;
@@ -66,8 +63,6 @@ export const SpørsmålElement = styled.div`
 export const RadioknappWrapper = styled.div`
   margin-top: 1rem;
   margin-bottom: 1rem;
-
-  padding-left: ${størrelse.spørsmålTekstPadding};
 
   .inputPanel {
     margin: 0 auto;

--- a/src/components/veiviser-header/Header.tsx
+++ b/src/components/veiviser-header/Header.tsx
@@ -1,13 +1,13 @@
 import { IHeader } from '../../models/Header';
 import {
   Ingress,
-  MikroKortWrapper,
   Overskrift,
   StyledVeiviserIkon,
   VeiviserHeader,
 } from './VeiviserHeaderElementer';
-import MikroKort from '../mikrokort/MikroKort';
+import { MikroKort } from '../mikrokort/MikroKort';
 import { logNavigering } from '../../utils/amplitude';
+import { VStack } from '@navikt/ds-react';
 
 interface IProps {
   tekst: IHeader;
@@ -26,7 +26,7 @@ const Header: React.FC<IProps> = ({ tekst }) => {
       <Overskrift>{tekst.overskrift}</Overskrift>
       <hr aria-hidden={true} />
       <Ingress markdown={tekst.ingress} />
-      <MikroKortWrapper>
+      <VStack gap={'2'}>
         <h3 id={'mikrokort_tittel'}>Mer om hva du kan ha rett til når du</h3>
         <MikroKort
           href="https://www.nav.no/alene-med-barn"
@@ -40,7 +40,7 @@ const Header: React.FC<IProps> = ({ tekst }) => {
         >
           Er helt eller delvis alene med barn
         </MikroKort>
-      </MikroKortWrapper>
+      </VStack>
     </VeiviserHeader>
   );
 };

--- a/src/components/veiviser-header/VeiviserHeaderElementer.ts
+++ b/src/components/veiviser-header/VeiviserHeaderElementer.ts
@@ -4,18 +4,6 @@ import VeiviserIkon from '../../icons/VeiviserIkon';
 import { device, størrelse } from '../../utils/styles';
 import { AGray900, APurple200 } from '@navikt/ds-tokens/dist/tokens';
 
-export const MikroKortWrapper = styled.div`
-  padding-left: 3rem;
-
-  @media ${device.mobile} {
-    padding-left: 0;
-  }
-
-  @media ${device.tablet} {
-    padding-left: 0;
-  }
-`;
-
 export const VeiviserHeader = styled.div`
   @media ${device.mobile} {
     padding-left: 2rem;
@@ -28,8 +16,6 @@ export const VeiviserHeader = styled.div`
   }
 
   p {
-    padding-left: ${størrelse.spørsmålTekstPadding};
-
     width: ${størrelse.panelInnholdBredde};
     font-size: 20px;
 
@@ -53,8 +39,6 @@ export const VeiviserHeader = styled.div`
   }
 
   ul {
-    padding-left: 4.5rem;
-
     @media ${device.tablet} {
       width: 100%;
       margin: 0 auto;
@@ -81,8 +65,6 @@ export const StyledVeiviserIkon = styled(VeiviserIkon)`
 
 export const Ingress = styled(MarkdownViewer)`
   ul {
-    padding-left: 4.5rem;
-
     @media ${device.tablet} {
       width: 100%;
       margin: 0 auto;

--- a/src/global.css
+++ b/src/global.css
@@ -7,8 +7,6 @@ body {
   margin: 0;
 
   a:focus {
-    color: var(--a-gray-700);
     text-decoration: none;
-    background-color: var(--a-orange-500);
   }
 }

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -7,5 +7,4 @@ export const device = {
 export const størrelse = {
   panelBredde: '792px',
   panelInnholdBredde: '588px',
-  spørsmålTekstPadding: '3.3rem',
 };


### PR DESCRIPTION
Skal skrive oss bort fra styled-component. 

* Fjerner unødvendig styling.
* Bruker css-moduler der det er nødvendig.

Før:
<img width="1586" height="1504" alt="image" src="https://github.com/user-attachments/assets/59d4ed31-ab64-4c4b-b8e4-3e3484b4b860" />

Etter:
<img width="3448" height="1756" alt="image" src="https://github.com/user-attachments/assets/da69d2ac-f962-4e4f-bbb9-51777fe4f6c1" />

<img width="850" height="1602" alt="image" src="https://github.com/user-attachments/assets/ee33f737-7f27-414f-98d4-0be1ffb8b39e" />

